### PR TITLE
New feature review campsite

### DIFF
--- a/parkfinite2/components/StarRating.tsx
+++ b/parkfinite2/components/StarRating.tsx
@@ -6,7 +6,7 @@ import { Animated, StyleSheet, View, Text, TouchableWithoutFeedback } from "reac
 export type StarRating = number | null;
 
 type StarRatingProps = {
-  initialRating: StarRating,
+  initialRating?: StarRating,
   onRatingChange: (rating: StarRating) => void
 }
 

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/campsite-reviews.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/campsite-reviews.tsx
@@ -7,11 +7,15 @@ import { convertNumberToStars } from "@/utils/convertNumberToStars";
 
 type CampsiteReviewsProps = {
   campsiteId: number;
+  campsiteReviews: CampsiteReview[];
+  setCampsiteReviews: (value: CampsiteReview[]) => void;
 };
 
-export default function CampsiteReviews({ campsiteId }: CampsiteReviewsProps) {
-  const [campsiteReviews, setCampsiteReviews] = useState<CampsiteReview[]>([]);
-
+export default function CampsiteReviews({
+  campsiteId,
+  campsiteReviews,
+  setCampsiteReviews,
+}: CampsiteReviewsProps) {
   useEffect(() => {
     getReviewsByCampsiteId(campsiteId).then((reviewsFromApi) => {
       setCampsiteReviews(reviewsFromApi);
@@ -36,7 +40,9 @@ export default function CampsiteReviews({ campsiteId }: CampsiteReviewsProps) {
             </View>
           ))
         ) : (
-          <Text style={campsiteDetailedCardStyles.italicText}>Be the first to review this campsite...</Text>
+          <Text style={campsiteDetailedCardStyles.italicText}>
+            Be the first to review this campsite...
+          </Text>
         )}
       </View>
     </>

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -6,6 +6,7 @@ import StarRatingComponent, { StarRating } from "@/components/StarRating";
 import { Button } from "@/components/Button";
 import { CampsiteReviewPostRequest } from "@/types/api-data-types/campsite-types";
 import { UserContext } from "@/contexts/UserContext";
+import FieldAndDataText from "@/components/FieldAndDataText";
 
 type PostCampsiteReviewProps = {
   campsiteId: number;
@@ -15,7 +16,6 @@ export default function PostCampsiteReview({
   campsiteId,
 }: PostCampsiteReviewProps) {
   const { user } = useContext(UserContext);
-  const [rating, setRating] = useState<StarRating>(null);
   const { control, handleSubmit, setValue } =
     useForm<CampsiteReviewPostRequest>({
       defaultValues: {
@@ -24,15 +24,14 @@ export default function PostCampsiteReview({
       },
     });
 
-  const handleRatingChange = (rating: StarRating) => {
-    setRating(rating);
-  };
-
   return (
     <View style={campsiteDetailedCardStyles.container}>
       <Text>PostCampsiteReview</Text>
 
-      <StarRatingComponent onRatingChange={handleRatingChange} />
+      <Controller control={control} name="rating" rules={{required:true}}
+      render={({ field: { onChange, value } }) => (
+        <StarRatingComponent onRatingChange={onChange} />
+      )} />
 
       <Controller
         control={control}

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -37,11 +37,10 @@ export default function PostCampsiteReview({
     }
     const tempReviewID = Number(`-${campsiteId}${user?.user_account_id}${Date.now()}`);
     const optimisticReview = ({
-      rating: data.rating,
-      comment: data.comment,
-      username: user?.username,
-      campsite_id: campsiteId,
+      ...data,
       review_id: tempReviewID,
+      campsite_id: campsiteId,
+      username: user.username,
     });
 
     try {

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -1,7 +1,10 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { Text, View } from "react-native";
+import { useForm } from "react-hook-form";
 import { campsiteDetailedCardStyles } from "../individual-campsite-styles";
 import StarRatingComponent, { StarRating } from "@/components/StarRating";
+import { CampsiteReviewPostRequest } from "@/types/api-data-types/campsite-types";
+import { UserContext } from "@/contexts/UserContext";
 
 type PostCampsiteReviewProps = {
   campsiteId: number;
@@ -10,7 +13,15 @@ type PostCampsiteReviewProps = {
 export default function PostCampsiteReview({
   campsiteId,
 }: PostCampsiteReviewProps) {
+  const { user } = useContext(UserContext);
   const [rating, setRating] = useState<StarRating>(null);
+  const {control, handleSubmit, setValue} = useForm<CampsiteReviewPostRequest>({
+    defaultValues: {
+      rating: rating,
+      user_account_id: user?.user_account_id,
+      comment: null,
+    }
+  });
 
   const handleRatingChange = (rating: number) => {
     setRating(rating);
@@ -23,6 +34,7 @@ export default function PostCampsiteReview({
         initialRating={rating}
         onRatingChange={handleRatingChange}
       />
+
     </View>
   );
 }

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -11,10 +11,12 @@ import { postReviewByCampsiteId } from "@/services/api/campsitesApi";
 
 type PostCampsiteReviewProps = {
   campsiteId: number;
+  setUserHasReviewed: (value: boolean) => void;
 };
 
 export default function PostCampsiteReview({
   campsiteId,
+  setUserHasReviewed
 }: PostCampsiteReviewProps) {
   const { user } = useContext(UserContext);
   const { control, handleSubmit, setValue } =
@@ -52,6 +54,7 @@ export default function PostCampsiteReview({
         title="Submit review"
         onPress={handleSubmit((data) => {
           postReviewByCampsiteId(campsiteId, data);
+          setUserHasReviewed(true);
         })}
       />
     </View>

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -1,14 +1,28 @@
+import { useState } from "react";
 import { Text, View } from "react-native";
 import { campsiteDetailedCardStyles } from "../individual-campsite-styles";
+import StarRatingComponent, { StarRating } from "@/components/StarRating";
 
 type PostCampsiteReviewProps = {
-    campsiteId: number;
-}
+  campsiteId: number;
+};
 
-export default function PostCampsiteReview({campsiteId} : PostCampsiteReviewProps) {
+export default function PostCampsiteReview({
+  campsiteId,
+}: PostCampsiteReviewProps) {
+  const [rating, setRating] = useState<StarRating>(null);
+
+  const handleRatingChange = (rating: number) => {
+    setRating(rating);
+  };
+
   return (
     <View style={campsiteDetailedCardStyles.container}>
       <Text>PostCampsiteReview</Text>
+      <StarRatingComponent
+        initialRating={rating}
+        onRatingChange={handleRatingChange}
+      />
     </View>
   );
-} 
+}

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/Button";
 import { CampsiteReviewPostRequest } from "@/types/api-data-types/campsite-types";
 import { UserContext } from "@/contexts/UserContext";
 import FieldAndDataText from "@/components/FieldAndDataText";
+import { postReviewByCampsiteId } from "@/services/api/campsitesApi";
 
 type PostCampsiteReviewProps = {
   campsiteId: number;
@@ -50,7 +51,7 @@ export default function PostCampsiteReview({
       <Button
         title="Submit review"
         onPress={handleSubmit((data) => {
-          console.log(data);
+          postReviewByCampsiteId(campsiteId, data);
         })}
       />
     </View>

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -73,13 +73,23 @@ export default function PostCampsiteReview({
               username: user?.username,
               campsite_id: campsiteId,
               review_id: tempReviewID,
-            };  
+            };
             setUserHasReviewed(true);
             setCampsiteReviews((prevReviews: CampsiteReview[]) => [
               ...prevReviews,
               newReview,
             ]);
-            postReviewByCampsiteId(campsiteId, data);
+            const reviewFromApi = await postReviewByCampsiteId(
+              campsiteId,
+              data
+            );
+            setCampsiteReviews((prevReviews: CampsiteReview[]) =>
+              prevReviews.map((review) =>
+                review.review_id === tempReviewID
+                  ? { ...reviewFromApi }
+                  : review
+              )
+            );
           } catch (error) {
             setUserHasReviewed(false);
             alert("Failed to post review. Please try again later.");

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -16,7 +16,7 @@ type PostCampsiteReviewProps = {
 
 export default function PostCampsiteReview({
   campsiteId,
-  setUserHasReviewed
+  setUserHasReviewed,
 }: PostCampsiteReviewProps) {
   const { user } = useContext(UserContext);
   const { control, handleSubmit, setValue } =
@@ -31,10 +31,14 @@ export default function PostCampsiteReview({
     <View style={campsiteDetailedCardStyles.container}>
       <Text>PostCampsiteReview</Text>
 
-      <Controller control={control} name="rating" rules={{required:true}}
-      render={({ field: { onChange, value } }) => (
-        <StarRatingComponent onRatingChange={onChange} />
-      )} />
+      <Controller
+        control={control}
+        name="rating"
+        rules={{ required: true }}
+        render={({ field: { onChange, value } }) => (
+          <StarRatingComponent onRatingChange={onChange} />
+        )}
+      />
 
       <Controller
         control={control}
@@ -52,9 +56,14 @@ export default function PostCampsiteReview({
 
       <Button
         title="Submit review"
-        onPress={handleSubmit((data) => {
-          postReviewByCampsiteId(campsiteId, data);
-          setUserHasReviewed(true);
+        onPress={handleSubmit(async (data) => {
+          try {
+            postReviewByCampsiteId(campsiteId, data);
+            setUserHasReviewed(true);
+          } catch (error) {
+            alert("Failed to post review. Please try again later.");
+            setUserHasReviewed(false);
+          }
         })}
       />
     </View>

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -33,6 +33,20 @@ export default function PostCampsiteReview({
 
       <StarRatingComponent onRatingChange={handleRatingChange} />
 
+      <Controller
+        control={control}
+        name="comment"
+        rules={{ required: false, minLength: 4, maxLength: 500 }}
+        render={({ field: { onChange, value } }) => (
+          <TextInput
+            style={campsiteDetailedCardStyles.textInput}
+            placeholder="Leave a comment..."
+            onChangeText={onChange}
+            value={value ?? ""}
+          />
+        )}
+      />
+      
     </View>
   );
 }

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -1,0 +1,14 @@
+import { Text, View } from "react-native";
+import { campsiteDetailedCardStyles } from "../individual-campsite-styles";
+
+type PostCampsiteReviewProps = {
+    campsiteId: number;
+}
+
+export default function PostCampsiteReview({campsiteId} : PostCampsiteReviewProps) {
+  return (
+    <View style={campsiteDetailedCardStyles.container}>
+      <Text>PostCampsiteReview</Text>
+    </View>
+  );
+} 

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -3,6 +3,7 @@ import { Text, TextInput, View } from "react-native";
 import { Controller, useForm } from "react-hook-form";
 import { campsiteDetailedCardStyles } from "../individual-campsite-styles";
 import StarRatingComponent, { StarRating } from "@/components/StarRating";
+import { Button } from "@/components/Button";
 import { CampsiteReviewPostRequest } from "@/types/api-data-types/campsite-types";
 import { UserContext } from "@/contexts/UserContext";
 
@@ -46,7 +47,13 @@ export default function PostCampsiteReview({
           />
         )}
       />
-      
+
+      <Button
+        title="Submit review"
+        onPress={handleSubmit((data) => {
+          console.log(data);
+        })}
+      />
     </View>
   );
 }

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-components/post-campsite-review.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState } from "react";
-import { Text, View } from "react-native";
-import { useForm } from "react-hook-form";
+import { Text, TextInput, View } from "react-native";
+import { Controller, useForm } from "react-hook-form";
 import { campsiteDetailedCardStyles } from "../individual-campsite-styles";
 import StarRatingComponent, { StarRating } from "@/components/StarRating";
 import { CampsiteReviewPostRequest } from "@/types/api-data-types/campsite-types";
@@ -15,25 +15,23 @@ export default function PostCampsiteReview({
 }: PostCampsiteReviewProps) {
   const { user } = useContext(UserContext);
   const [rating, setRating] = useState<StarRating>(null);
-  const {control, handleSubmit, setValue} = useForm<CampsiteReviewPostRequest>({
-    defaultValues: {
-      rating: rating,
-      user_account_id: user?.user_account_id,
-      comment: null,
-    }
-  });
+  const { control, handleSubmit, setValue } =
+    useForm<CampsiteReviewPostRequest>({
+      defaultValues: {
+        user_account_id: user?.user_account_id,
+        comment: null,
+      },
+    });
 
-  const handleRatingChange = (rating: number) => {
+  const handleRatingChange = (rating: StarRating) => {
     setRating(rating);
   };
 
   return (
     <View style={campsiteDetailedCardStyles.container}>
       <Text>PostCampsiteReview</Text>
-      <StarRatingComponent
-        initialRating={rating}
-        onRatingChange={handleRatingChange}
-      />
+
+      <StarRatingComponent onRatingChange={handleRatingChange} />
 
     </View>
   );

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-screen.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-screen.tsx
@@ -39,8 +39,18 @@ export default function IndividualCampsiteScreen({
           {loadedCampsite.contacts[0] && (
             <CampsiteContacts campsiteContacts={loadedCampsite.contacts} />
           )}
-          {!userHasReviewed && <PostCampsiteReview campsiteId={loadedCampsite.campsite_id} setUserHasReviewed={setUserHasReviewed}/>}
-          <CampsiteReviews campsiteId={loadedCampsite.campsite_id} campsiteReviews={campsiteReviews} setCampsiteReviews={setCampsiteReviews} />
+          {!userHasReviewed && (
+            <PostCampsiteReview
+              campsiteId={loadedCampsite.campsite_id}
+              setUserHasReviewed={setUserHasReviewed}
+              setCampsiteReviews={setCampsiteReviews}
+            />
+          )}
+          <CampsiteReviews
+            campsiteId={loadedCampsite.campsite_id}
+            campsiteReviews={campsiteReviews}
+            setCampsiteReviews={setCampsiteReviews}
+          />
         </ScrollView>
       )}
     </>

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-screen.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-screen.tsx
@@ -19,6 +19,7 @@ export default function IndividualCampsiteScreen({
   id,
 }: IndividualCampsiteScreenProps) {
   const [loadedCampsite, setLoadedCampsite] = useState<Campsite | null>(null);
+  const [userHasReviewed, setUserHasReviewed] = useState<boolean>(false);
 
   useEffect(() => {
     getCampsiteById(id).then((campsiteFromApi) =>
@@ -36,7 +37,7 @@ export default function IndividualCampsiteScreen({
           {loadedCampsite.contacts[0] && (
             <CampsiteContacts campsiteContacts={loadedCampsite.contacts} />
           )}
-          <PostCampsiteReview campsiteId={loadedCampsite.campsite_id} />
+          {!userHasReviewed && <PostCampsiteReview campsiteId={loadedCampsite.campsite_id} setUserHasReviewed={setUserHasReviewed}/>}
           <CampsiteReviews campsiteId={loadedCampsite.campsite_id} />
         </ScrollView>
       )}

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-screen.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-screen.tsx
@@ -9,6 +9,7 @@ import CampsiteBasicInfo from "./individual-campsite-components/campsite-basic-i
 import CampsiteContacts from "./individual-campsite-components/campsite-contacts";
 import CampsiteHeaderAndRating from "./individual-campsite-components/campsite-header-and-rating";
 import CampsiteReviews from "./individual-campsite-components/campsite-reviews";
+import PostCampsiteReview from "./individual-campsite-components/post-campsite-review";
 
 type IndividualCampsiteScreenProps = {
   id: string | string[];
@@ -35,6 +36,7 @@ export default function IndividualCampsiteScreen({
           {loadedCampsite.contacts[0] && (
             <CampsiteContacts campsiteContacts={loadedCampsite.contacts} />
           )}
+          <PostCampsiteReview campsiteId={loadedCampsite.campsite_id} />
           <CampsiteReviews campsiteId={loadedCampsite.campsite_id} />
         </ScrollView>
       )}

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-screen.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-screen.tsx
@@ -3,6 +3,7 @@ import { ScrollView } from "react-native";
 
 import { getCampsiteById } from "@/services/api/campsitesApi";
 import { Campsite } from "@/types/api-data-types/campsite-types";
+import { CampsiteReview } from "@/types/api-data-types/campsite-types";
 
 import { ImageCarousel } from "@/components/ImageCarousel";
 import CampsiteBasicInfo from "./individual-campsite-components/campsite-basic-info";
@@ -19,6 +20,7 @@ export default function IndividualCampsiteScreen({
   id,
 }: IndividualCampsiteScreenProps) {
   const [loadedCampsite, setLoadedCampsite] = useState<Campsite | null>(null);
+  const [campsiteReviews, setCampsiteReviews] = useState<CampsiteReview[]>([]);
   const [userHasReviewed, setUserHasReviewed] = useState<boolean>(false);
 
   useEffect(() => {
@@ -38,7 +40,7 @@ export default function IndividualCampsiteScreen({
             <CampsiteContacts campsiteContacts={loadedCampsite.contacts} />
           )}
           {!userHasReviewed && <PostCampsiteReview campsiteId={loadedCampsite.campsite_id} setUserHasReviewed={setUserHasReviewed}/>}
-          <CampsiteReviews campsiteId={loadedCampsite.campsite_id} />
+          <CampsiteReviews campsiteId={loadedCampsite.campsite_id} campsiteReviews={campsiteReviews} setCampsiteReviews={setCampsiteReviews} />
         </ScrollView>
       )}
     </>

--- a/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-styles.tsx
+++ b/parkfinite2/components/map-drawer/map-tab/individual-campsite-stack/individual-campsite-styles.tsx
@@ -49,5 +49,15 @@ export const campsiteDetailedCardStyles = StyleSheet.create({
   },
   italicText: {
     fontStyle: "italic"
-  }
+  },
+  textInput: {
+    height: 40,
+    marginTop: 3,
+    marginBottom: 3,
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 10,
+    minWidth: "80%",
+    backgroundColor: "#d8f3d8",
+  },
 });

--- a/parkfinite2/services/api/campsitesApi.tsx
+++ b/parkfinite2/services/api/campsitesApi.tsx
@@ -105,7 +105,7 @@ export function postReviewByCampsiteId(
     });
 }
 
-export function getReviewsByCampsiteId(campsiteId: string | string[]) {
+export function getReviewsByCampsiteId(campsiteId: number) {
   return parkfinite2Api
     .get<CampsiteReview[]>(`/campsites/${campsiteId}/reviews`)
     .then((res) => {

--- a/parkfinite2/types/api-data-types/campsite-types.ts
+++ b/parkfinite2/types/api-data-types/campsite-types.ts
@@ -46,7 +46,7 @@ export interface Campsite {
 export interface CampsiteReview {
   rating: number;
   username: string;
-  comment: string;
+  comment: string | null;
   review_id: number;
   campsite_id: number;
 }


### PR DESCRIPTION
Creates functionality allowing user to post a campsite review from the Individual Campsite Review screen:
- creates PostReview component and conditionally renders it in the individual campsite screen if a user hasn't already posted a review on this instance of viewing the individual campsite screen - this prevents spamming while allowing a user to make repeat reviews for multiple stays
- requires user to rate the campsite out of 5, with an optional comment
- optimistically renders review while asynchronously posting the review to the api. Once the new review (with db generated id) is returned from the http request, the optimistically rendered review is replaced with the api stored review. 